### PR TITLE
`RootControllerCrossDissolveTransition` improvements

### DIFF
--- a/Examples/RoutingExample/Routing/Routing.swift
+++ b/Examples/RoutingExample/Routing/Routing.swift
@@ -25,6 +25,7 @@ typealias PushTransition = ViewRouting.PushTransition
 typealias ModalTransition = ViewRouting.ModalTransition
 typealias Routable = ViewRouting.Routable
 typealias RootControllerCrossDissolveTransition = ViewRouting.RootControllerCrossDissolveTransition
+typealias ActiveSceneFirstWindowProvider = ViewRouting.ActiveSceneFirstWindowProvider
 
 
 // MARK: - DeeplinkingRouting Definitions

--- a/Examples/RoutingExample/Screens/Main Flow/Tab Bar/MainTabBarRoute.swift
+++ b/Examples/RoutingExample/Screens/Main Flow/Tab Bar/MainTabBarRoute.swift
@@ -39,7 +39,7 @@ extension MainTabBarRoute where Self: Routable {
         let tabBarController = MainTabBarController(allTabs: sortedTabs,
                                                     selection: selection)
         
-        route(to: tabBarController, as: RootControllerCrossDissolveTransition())
+        route(to: tabBarController, as: RootControllerCrossDissolveTransition(windowProvider: ActiveSceneFirstWindowProvider()))
         mainRouter.root = tabBarController
         selection.selectedTab = tab
         return tabBarController

--- a/Sources/ViewRouting/Transitions/RootControllerCrossDissolveTransition.swift
+++ b/Sources/ViewRouting/Transitions/RootControllerCrossDissolveTransition.swift
@@ -10,15 +10,54 @@
 import Foundation
 import UIKit
 
+// MARK: - RootControllerCrossDissolveTransition Dependencies
+
+public protocol WindowProvider {
+    func window(for: UIViewController) -> UIWindow?
+}
+
+public final class PresentedControllerWindowProvider: WindowProvider {
+    
+    public init() { }
+    
+    public func window(for viewController: UIViewController) -> UIWindow? {
+        viewController.view.window
+    }
+}
+
+public protocol WindowSceneProvider {
+    var connectedScenes: Set<UIScene> { get }
+}
+
+extension UIApplication: WindowSceneProvider { }
+
+public final class ActiveSceneFirstWindowProvider: WindowProvider {
+    
+    private let application: WindowSceneProvider
+    
+    public init(application: WindowSceneProvider = UIApplication.shared) {
+        self.application = application
+    }
+    
+    public func window(for viewController: UIViewController) -> UIWindow? {
+        windowScene?.windows.first
+    }
+    
+    private var windowScene: UIWindowScene? {
+        application.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
+    }
+}
+
 // MARK: - Definition
 
 /// Transition that swaps the root view controller of the window,
 /// in which the `from` view controller is presented, with the
 /// `viewController` that you want to transition to.
 public final class RootControllerCrossDissolveTransition {
-   public var isAnimated: Bool
-    var animationOptions: UIView.AnimationOptions
-    var animationDuration: TimeInterval
+    public var isAnimated: Bool
+    private let animationOptions: UIView.AnimationOptions
+    private let animationDuration: TimeInterval
+    private let windowProvider: WindowProvider
     
     /// Memory hook, used for closing down the transition.
     /// Weak reference is used, so that the view controller
@@ -26,19 +65,23 @@ public final class RootControllerCrossDissolveTransition {
     /// back to.
     private weak var fromController: UIViewController?
     
-    public init(isAnimated: Bool = true, animationDuration: TimeInterval = 0.3, animationOptions: UIView.AnimationOptions = [.transitionCrossDissolve]) {
+    public init(isAnimated: Bool = true,
+                animationDuration: TimeInterval = 0.3,
+                animationOptions: UIView.AnimationOptions = [.transitionCrossDissolve],
+                windowProvider: WindowProvider = PresentedControllerWindowProvider()) {
         self.isAnimated = isAnimated
         self.animationDuration = animationDuration
         self.animationOptions = animationOptions
+        self.windowProvider = windowProvider
     }
 }
 
 // MARK: - Transition Conformance
 
 extension RootControllerCrossDissolveTransition: Transition {
-
+    
     public func open(_ viewController: UIViewController, from: UIViewController, completion: (() -> Void)?) {
-        guard let window = from.view.window else {
+        guard let window = windowProvider.window(for: viewController) else {
             print("[RootControllerCrossDissolveTransition] transition failed, as `from.view.window` was nil")
             return
         }


### PR DESCRIPTION
`RootControllerCrossDissolveTransition` got an injected abstract window provider logic, with 2 local defaults - `PresentedControllerWindowProvider` and `ActiveSceneFirstWindowProvider`